### PR TITLE
Able to crop images into any rectangular size and fill their background ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ Usage
             ...
         </plugins>
     </build>
+
+    In addition to scaling, it is possible to add black padding around images 
+    and crop them to specified size. Useful to when generating initial 
+    image for iPhone or iPad:
+
+    <image>
+        <source>src/main/icons/launcher.png</source>
+        <destination>Default@2x.png</destination>
+        <width>240</width>
+        <cropWidth>640</cropWidth>
+        <cropHeight>960</cropHeight>
+    </image>
+

--- a/README.md
+++ b/README.md
@@ -55,5 +55,9 @@ Usage
         <width>240</width>
         <cropWidth>640</cropWidth>
         <cropHeight>960</cropHeight>
+        <color>black</code>
     </image>
 
+    The color can be specified by name of one fields of java.awt.Color,
+    or by integer value: <color>0xffff00</color> is the same as
+    <color>yellow</color>.

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,12 @@
             <type>jar</type>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.10</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/filmon/maven/Image.java
+++ b/src/main/java/com/filmon/maven/Image.java
@@ -6,6 +6,8 @@ public class Image {
     private File source;
     private String destination;
     private int width;
+    private Integer cropWidth;
+    private Integer cropHeight;
 
     public File getSource() {
         return source;
@@ -29,5 +31,18 @@ public class Image {
 
     public void setWidth(final Integer width) {
         this.width = width;
+    }
+    
+    public void setCropWidth(Integer width) {
+        this.cropWidth = width;
+    }
+    public void setCropHeight(Integer height) {
+        this.cropHeight = height;
+    }
+    Integer getCropWidth() {
+        return cropWidth;
+    }
+    Integer getCropHeight() {
+        return cropHeight;
     }
 }

--- a/src/main/java/com/filmon/maven/Image.java
+++ b/src/main/java/com/filmon/maven/Image.java
@@ -1,6 +1,9 @@
 package com.filmon.maven;
 
+import java.awt.Color;
 import java.io.File;
+import java.lang.reflect.Field;
+import org.apache.maven.plugin.MojoExecutionException;
 
 public class Image {
     private File source;
@@ -8,6 +11,7 @@ public class Image {
     private int width;
     private Integer cropWidth;
     private Integer cropHeight;
+    private String color;
 
     public File getSource() {
         return source;
@@ -39,10 +43,27 @@ public class Image {
     public void setCropHeight(Integer height) {
         this.cropHeight = height;
     }
+    public void setColor(String color) {
+        this.color = color;
+    }
     Integer getCropWidth() {
         return cropWidth;
     }
     Integer getCropHeight() {
         return cropHeight;
+    }
+    Color getColor() throws MojoExecutionException {
+        if (color == null) return null;
+        try {
+            Field f = Color.class.getField(color);
+            return (Color) f.get(null);
+        } catch (Exception ex) {
+            // ignore
+        }
+        try {
+            return Color.decode(color);
+        } catch (NumberFormatException ex) {
+            throw new MojoExecutionException("Does not represent color: " + color, ex);
+        }
     }
 }

--- a/src/main/java/com/filmon/maven/ScaleImageMojo.java
+++ b/src/main/java/com/filmon/maven/ScaleImageMojo.java
@@ -1,5 +1,6 @@
 package com.filmon.maven;
 
+import java.awt.Color;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
@@ -75,7 +76,12 @@ public class ScaleImageMojo extends AbstractMojo {
             if (cropHeight != null && cropWidth != null) {
                 int max = Math.max(cropHeight, cropWidth);
                 if (max > width) {
-                    thumbnail = Scalr.pad(thumbnail, (max - width) / 2);
+                    final Color color = imageDefinition.getColor();
+                    if (color == null) {
+                        thumbnail = Scalr.pad(thumbnail, (max - width) / 2);
+                    } else {
+                        thumbnail = Scalr.pad(thumbnail, (max - width) / 2, color);
+                    }
                 }
                 int x = (max - cropWidth) / 2;
                 int y = (max - cropHeight) / 2;

--- a/src/main/java/com/filmon/maven/ScaleImageMojo.java
+++ b/src/main/java/com/filmon/maven/ScaleImageMojo.java
@@ -65,11 +65,22 @@ public class ScaleImageMojo extends AbstractMojo {
 
             final Integer width = imageDefinition.getWidth();
 
-            final BufferedImage thumbnail = Scalr.resize(
+            BufferedImage thumbnail = Scalr.resize(
                     getInputImage(input),
                     Scalr.Method.ULTRA_QUALITY,
                     width
             );
+            final Integer cropHeight = imageDefinition.getCropHeight();
+            final Integer cropWidth = imageDefinition.getCropWidth();
+            if (cropHeight != null && cropWidth != null) {
+                int max = Math.max(cropHeight, cropWidth);
+                if (max > width) {
+                    thumbnail = Scalr.pad(thumbnail, (max - width) / 2);
+                }
+                int x = (max - cropWidth) / 2;
+                int y = (max - cropHeight) / 2;
+                thumbnail = Scalr.crop(thumbnail, x, y, cropWidth, cropHeight);
+            }
 
             writeImage(thumbnail, getFormatName(input), output);
 

--- a/src/test/java/com/filmon/maven/ImageTest.java
+++ b/src/test/java/com/filmon/maven/ImageTest.java
@@ -1,0 +1,41 @@
+package com.filmon.maven;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ImageTest {
+    @Test public void whiteByName() throws Exception {
+        Image img = new Image();
+        img.setColor("white");
+        assertEquals(255, img.getColor().getRed());
+        assertEquals(255, img.getColor().getGreen());
+        assertEquals(255, img.getColor().getBlue());
+    }
+    @Test public void yelloByName() throws Exception {
+        Image img = new Image();
+        img.setColor("yellow");
+        assertEquals(255, img.getColor().getRed());
+        assertEquals(255, img.getColor().getGreen());
+        assertEquals(0, img.getColor().getBlue());
+    }
+    @Test public void yelloByValue() throws Exception {
+        Image img = new Image();
+        img.setColor("0xffff00");
+        assertEquals(255, img.getColor().getRed());
+        assertEquals(255, img.getColor().getGreen());
+        assertEquals(0, img.getColor().getBlue());
+    }
+    @Test public void exceptionAtNonsense() {
+        try {
+            Image img = new Image();
+            img.setColor("makesNoSense");
+            img.getColor();
+        } catch (MojoExecutionException ex) {
+            return;
+        }
+        fail("MojoExecutionException should be thrown");
+    }
+    
+       
+}


### PR DESCRIPTION
Hi.
I am using your plugin to generate icons of different scale for my Android and iOS application (Fair Minesweeper, read more at http://xelfi.cz/minesweeper/bck2brwsr/) and I'd like to use it to generate initial screens with logo as well. For that I need ability to add padding around the scaled icon. I have created a patch which works for my case.

Would you be so kind to accept my pull request and then release new version of your Maven plugin? Thanks.
